### PR TITLE
Rework the sorting control on the word list

### DIFF
--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -615,8 +615,8 @@ button {
 }
 
 .sort-trigger-icon {
-    width: 0.875rem;
-    height: 0.875rem;
+    width: 1rem;
+    height: 1rem;
 }
 
 .sort-dropdown {

--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -105,12 +105,6 @@ button {
     --el-color-white: #3a3a3a;
     --el-pagination-hover-color: #868686;
 }
-.el-select-dropdown {
-    --el-color-primary: var(--primary-color);
-    --el-select-border-color-hover: red;
-    --el-border-color-hover: red;
-    --el-input-hover-border-color: red;
-}
 .login {
     background: var(--purple-grad);
     text-align: center;
@@ -597,11 +591,41 @@ button {
     color: rgb(255, 255, 255);
 }
 
-.all-words-title {
-    margin-top: 1rem;
+.sort-settings {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    /* пад полем пошуку ўжо ёсць 32px пустой шапкі — свайго водступу не трэба */
+    margin-top: 0;
+}
+
+.sort-trigger {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: none;
+    cursor: pointer;
     font-family: 'PT Sans Caption';
-    font-size: 1.5rem;
+    font-size: 1.25rem;
     color: rgb(255, 255, 255);
+}
+
+.sort-trigger:hover {
+    text-decoration: underline;
+}
+
+.sort-trigger-icon {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
+.sort-dropdown {
+    --el-font-size-base: 1.25rem;
+}
+
+.sort-dropdown,
+.sort-dropdown .el-dropdown-menu {
+    border-radius: 0;
 }
 
 .date-edit {
@@ -913,6 +937,9 @@ button {
 }
 
 @media screen and (max-width: 992px) {
+    .sort-settings {
+        margin-top: 1rem;
+    }
     .header-logo-btn {
         padding-left: 1rem;
         padding-top: 0.5rem;
@@ -1103,5 +1130,6 @@ button {
     /*---- end of mobile for hero ----*/
     .sort-settings {
         margin-left: 1rem;
+        margin-right: 1rem;
     }
 }

--- a/src/Terms.vue
+++ b/src/Terms.vue
@@ -1,10 +1,19 @@
 <template>
     <div class="main-container container">
         <div class="sort-settings">
-            <span class="all-words-title">Сартыроўка:</span>
-            <el-select v-model="sort" placeholder="Сартыроўка">
-                <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
-            </el-select>
+            <el-dropdown trigger="click" placement="bottom-end" popper-class="sort-dropdown" @command="onSortChange">
+                <button class="sort-trigger" type="button">
+                    {{ currentSortLabel }}
+                    <IconChevron class="sort-trigger-icon" />
+                </button>
+                <template #dropdown>
+                    <el-dropdown-menu>
+                        <el-dropdown-item v-for="item in otherSortOptions" :key="item.value" :command="item.value">
+                            {{ item.label }}
+                        </el-dropdown-item>
+                    </el-dropdown-menu>
+                </template>
+            </el-dropdown>
         </div>
         <PageContentSpinner v-if="!terms" />
         <div v-else class="cards-div">
@@ -101,7 +110,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { ElMessage } from 'element-plus';
 import { supabase } from './supabase.js';
@@ -111,19 +120,20 @@ import { getUser } from './auth.js';
 import IconDislike from './icons/IconDislike.vue';
 import IconLike from './icons/IconLike.vue';
 import PageContentSpinner from './PageContentSpinner.vue';
+import IconChevron from './icons/IconChevron.vue';
 
 const options = [
     {
         value: 'last',
-        label: 'Апошнія дададзеныя',
+        label: 'Спачатку новыя',
     },
     {
         value: 'first',
-        label: 'Першыя дадазеныя',
+        label: 'Спачатку даўнія',
     },
     {
         value: 'random',
-        label: 'Выпадковыя словы',
+        label: 'Выпадковыя',
     },
 ];
 
@@ -134,6 +144,14 @@ const terms = ref(null);
 const count = ref(0);
 const account = ref();
 const sort = ref('last');
+
+const currentSortLabel = computed(() => options.find((item) => item.value === sort.value).label);
+
+const otherSortOptions = computed(() => options.filter((item) => item.value !== sort.value));
+
+const onSortChange = (value) => {
+    sort.value = value;
+};
 
 const update = async (definition, type) => {
     if (!account.value) {

--- a/src/icons/IconChevron.vue
+++ b/src/icons/IconChevron.vue
@@ -1,0 +1,15 @@
+<template>
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+    >
+        <path d="M3 6L8 11L13 6" />
+    </svg>
+</template>

--- a/src/icons/IconChevron.vue
+++ b/src/icons/IconChevron.vue
@@ -6,7 +6,7 @@
         viewBox="0 0 16 16"
         fill="none"
         stroke="currentColor"
-        stroke-width="2"
+        stroke-width="2.5"
         stroke-linecap="round"
         stroke-linejoin="round"
     >


### PR DESCRIPTION
Presentation and wording only — the query and the sort options are unchanged.

The control was a grey form select pressed flush against the "Сартыроўка:" label (no gap at all between them, and the two were 3.5px out of vertical alignment). It is now part of the page's own typography: plain text plus a chevron, no border, no white box.

- 20px, the same size as the pagination below the list — sorting and paging both act on the list, and both are now quieter than the cards.
- Chevron drawn in the site's own icon language (round-capped stroke, like back.svg) rather than the Element Plus one.
- Square corners: the dropdown carried a 4px radius in two layers, while every other white block on the site is square.
- Right-aligned, so its right edge lines up with the search field and the cards.
- The "Сартыроўка:" label is gone — the option text now says what the order is, so a separate word for it is redundant.
- The current option is no longer repeated inside the menu; it is already shown on the trigger.
- Dropped the dead .el-select-dropdown rules: no el-select is left in the project and they carried leftover red debug borders.

Wording:
  Апошнія дададзеныя  -> Спачатку новыя
  Першыя дадазеныя    -> Спачатку даўнія
  Выпадковыя словы    -> Выпадковыя

"дадазеныя" was a typo, and "дададзены" is a form used nowhere else in the project — everywhere else it is "даданы" (Add.vue, Complain). "Старыя" was avoided on purpose: in a slang dictionary it reads as a judgement on the words themselves rather than on when they were added.