### PR TITLE
Align the sort menu with the right edge of the cards

### DIFF
--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -594,6 +594,9 @@ button {
 .sort-settings {
     display: flex;
     align-items: center;
+    /* управа на ўсіх шырынях: меню чапляецца за кнопку, таму толькі так яго правы
+       край супадае з правым краем карткі, а на вузкім экране — з краем іконак */
+    justify-content: flex-end;
     /* пад полем пошуку ўжо ёсць 32px пустой шапкі — свайго водступу не трэба */
     margin-top: 0;
 }
@@ -977,8 +980,12 @@ button {
         width: calc(100vw - 11rem);
     }
     .header-btns {
+        box-sizing: border-box;
         width: 10rem;
-        padding: 0;
+        /* іконкі прыціснутыя ўправа і адступаюць ад краю экрана гэтак жа, як усё
+           астатняе на старонцы — інакш бургер не супадаў з правым краем сартыроўкі */
+        padding: 0 1rem 0 0;
+        justify-content: flex-end;
     }
     .add-btn {
         margin: 0 0.5rem;

--- a/src/Terms.vue
+++ b/src/Terms.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="main-container container">
         <div class="sort-settings">
-            <el-dropdown trigger="click" popper-class="sort-dropdown" @command="onSortChange">
+            <el-dropdown trigger="click" placement="bottom-end" popper-class="sort-dropdown" @command="onSortChange">
                 <button class="sort-trigger" type="button">
                     {{ currentSortLabel }}
                     <IconChevron class="sort-trigger-icon" />


### PR DESCRIPTION
The menu opened below the trigger on the left and covered the first word on the card. It is now right-aligned, so it drops into the empty space to the right of the heading instead: the trigger, the menu, the card and the search field all end on the same line.

**Two things had to be fixed in the header for this to line up**

The icon block is a fixed 10rem wide while the icons themselves are narrower, so leftover space sat at its right end and the burger stopped wherever the row happened to end — a number that changed every time the burger's own margin was touched. The icons are now packed to the right and the block keeps the same 16px margin from the screen edge as everything else on the page, so the burger and the sort control end on the same line on narrow screens.

That block is also content-box, so adding the padding widened it past its 10rem and pushed the page into horizontal scroll. It is border-box now.

**Known, not fixed:** with a very long word the menu still clips the tail of the heading — 30px on "Як чуецца, так і пішацца". Removing that entirely would mean not overlaying the card at all, which is a different mechanism. The start of the word is always readable.

Checked at 375px and desktop: edges line up, no horizontal scroll, the header icons keep their spacing.