### PR TITLE
Make tags clickable, and mark the ones that lead nowhere

### DIFF
--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -596,7 +596,13 @@ button {
     align-items: center;
     /* управа на ўсіх шырынях: меню чапляецца за кнопку, таму толькі так яго правы
        край супадае з правым краем карткі, а на вузкім экране — з краем іконак */
-    justify-content: flex-end;
+    justify-content: space-between;
+    /* адваротны парадак: у разметцы чып ідзе пасля сартыроўкі, а бачны злева ад яе.
+       Дзякуючы гэтаму пры доўгім тэгу пераносіцца менавіта чып — пад сартыроўку,
+       а не над ёй */
+    flex-direction: row-reverse;
+    flex-wrap: wrap;
+    gap: 0.5rem;
     /* пад полем пошуку ўжо ёсць 32px пустой шапкі — свайго водступу не трэба */
     margin-top: 0;
 }
@@ -746,6 +752,52 @@ button {
 }
 .user-tag {
     background: #9ffc70;
+}
+
+/* зялёны — па тэгу можна перайсці, шэры — тэг ёсць толькі ў гэтага слова */
+.user-tag--lonely {
+    background: #eaeaea;
+}
+
+/* тэг-спасылка не павінна выглядаць як звычайная спасылка сайта:
+   не падкрэсліванне, а водгук памерам — так бачна, што гэта кнопка, а не тэкст */
+a.user-tag {
+    display: inline-block;
+    color: #494949;
+    text-decoration: none;
+    transition: transform 0.12s ease;
+}
+
+/* сціскаем, а не павялічваем: тэгі стаяць блізка, і той, што вырас, налазіць на суседзяў */
+a.user-tag:hover {
+    transform: scale(0.96);
+}
+
+a.user-tag:active {
+    transform: scale(0.92);
+}
+
+/* чып адбору — той самы тэг з карткі, толькі з крыжыкам */
+.sort-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    color: #494949;
+}
+
+.sort-tag__close {
+    background: none;
+    cursor: pointer;
+    color: inherit;
+    font-size: 1.25rem;
+    line-height: 1;
+    /* Тонкая рыска аддзяляе крыжык ад слова і ідзе на ўсю вышыню пілюлі.
+       Каб дацягнуцца да краёў, кнопка вылазіць за вертыкальныя палі .user-tag
+       (0.25rem зверху і знізу) адмоўнымі водступамі і дабірае іх сваімі. */
+    border-left: 1px solid currentColor;
+    margin-top: -0.25rem;
+    margin-bottom: -0.25rem;
+    padding: 0.25rem 0 0.25rem 0.375rem;
 }
 .embedded-tag {
     background: #d6fb89;

--- a/src/Navbar.vue
+++ b/src/Navbar.vue
@@ -104,12 +104,6 @@
             </template>
         </el-dropdown>
     </div>
-    <div class="navbar-tag-container" v-show="tags.length > 0">
-        Тэг: &nbsp;
-        <el-tag v-for="tag in tags" :key="tag.name" closable @close="handleClose" size="large" type="info">
-            {{ tag.name }}
-        </el-tag>
-    </div>
 </template>
 
 <script setup>
@@ -127,11 +121,7 @@ const account = ref();
 const oldAccountName = ref('');
 const accountName = ref('');
 const search = ref(route.query.poshuk?.trim() || '');
-const tags = ref([]);
 
-const handleClose = (tag) => {
-    tags.value.splice(tags.value.indexOf(tag), 1);
-};
 supabase.auth.onAuthStateChange((event, session) => {
     if (event === 'SIGNED_IN') {
         account.value = session.user;
@@ -199,34 +189,6 @@ onMounted(async () => {
 
 .dropdown_user_auth {
     width: 300px !important;
-}
-
-.navbar-tag-container {
-    height: 1rem;
-    min-width: 200px;
-    padding-top: 5px;
-    margin-bottom: 30px;
-    grid-column: 2;
-    font-family: 'PT Sans Caption';
-    font-size: 1.5rem;
-    color: rgb(255, 255, 255);
-    --el-color-info-light-9: #9ffc70;
-    --el-color-info-light-8: #9ffc70;
-}
-.navbar-tag-container .el-tag__content {
-    color: #494949;
-}
-.navbar-tag-container .el-tag {
-    --el-tag-border-radius: 0.75rem;
-    margin-right: 5px;
-}
-
-@media screen and (max-width: 992px) {
-    .navbar-tag-container {
-        padding-left: 1rem;
-        grid-row: 3;
-        grid-column: 1;
-    }
 }
 
 @media screen and (max-width: 700px) {

--- a/src/Terms.vue
+++ b/src/Terms.vue
@@ -14,6 +14,11 @@
                     </el-dropdown-menu>
                 </template>
             </el-dropdown>
+
+            <span v-if="tagQuery" class="user-tag sort-tag">
+                {{ tagQuery }}
+                <button class="sort-tag__close" type="button" title="Зняць адбор па тэгу" @click="clearTag">×</button>
+            </span>
         </div>
         <PageContentSpinner v-if="!terms" />
         <div v-else class="cards-div">
@@ -32,10 +37,12 @@
                     {{ item.example }}
                 </div>
                 <div class="card-tags">
-                    <span class="user-tag" v-for="tag of item.tags">
-                        {{ tag }}
-                    </span>
-                    <!-- <span class="embedded-tag">Tag2</span> -->
+                    <template v-for="tag of uniqueTags(item.tags)" :key="tag">
+                        <router-link v-if="isWalkable(tag)" class="user-tag" :to="{ name: 'terms', query: { tag } }">
+                            {{ tag }}
+                        </router-link>
+                        <span v-else class="user-tag user-tag--lonely">{{ tag }}</span>
+                    </template>
                 </div>
                 <div class="card-info">
                     <router-link
@@ -140,6 +147,93 @@ const options = [
 const router = useRouter();
 const route = useRoute();
 const searchQuery = route.query.poshuk?.trim();
+const tagQuery = route.query.tag?.trim();
+
+const clearTag = () => {
+    // чалавек прыйшоў сюды з нейкага месца спісу — вяртаем яго туды, разам са
+    // старонкай і месцам прокруткі. Калі ж тэг адкрылі па прамой спасылцы,
+    // вяртацца няма куды, таму проста здымаем адбор.
+    if (window.history.state?.back) {
+        router.back();
+        return;
+    }
+    const query = { ...route.query };
+    delete query.tag;
+    router.push({ name: 'terms', query });
+};
+
+// Колькі слоў мае кожны тэг. Лічым у браўзеры: бяром тэгі ўсіх слоў адным запытам
+// (пры 904 словах гэта каля 57 КБ) і трымаем да перазагрузкі.
+// ЧАСОВА, ПАКУЛЬ СЛОЎНІК МАЛЫ. Пры дзясятках тысяч слоў гэты спіс стане завялікім,
+// і лічыць колькасць трэба будзе на баку базы — вылічальным полем ва ўяўленні,
+// а не захаваным лічыльнікам, каб не разыходзіўся з праўдай.
+const tagUsage = ref(null);
+
+// адно і тое ж слова часам мае адзін тэг некалькі разоў: у табліцы сувязяў ляжаць
+// дублікаты радкоў, і забароны на паўтор там няма. Схлопваем пры паказе.
+const uniqueTags = (tags) => {
+    const seen = new Map();
+    for (const tag of tags || []) {
+        const key = tag.trim().toLowerCase();
+        if (key && !seen.has(key)) {
+            seen.set(key, tag.trim());
+        }
+    }
+    return [...seen.values()];
+};
+
+// тэг, які ёсць толькі ў аднаго слова, вядзе ў тупік — па ім не ходзім
+const isWalkable = (tag) => !tagUsage.value || (tagUsage.value.get(tag.trim().toLowerCase())?.count || 0) > 1;
+
+const loadTagUsage = async () => {
+    const usage = new Map();
+    const step = 1000;
+    for (let from = 0; ; from += step) {
+        const { data, error } = await supabase
+            .from('terms')
+            .select('tags')
+            .range(from, from + step - 1);
+        if (error) {
+            throw error;
+        }
+        for (const row of data) {
+            const counted = new Set();
+            for (const raw of row.tags || []) {
+                const key = raw.trim().toLowerCase();
+                if (!key) {
+                    continue;
+                }
+                if (!usage.has(key)) {
+                    usage.set(key, { count: 0, spellings: new Set() });
+                }
+                const entry = usage.get(key);
+                // слова лічым адзін раз, нават калі тэг паўтараецца ў ім некалькі разоў
+                if (!counted.has(key)) {
+                    counted.add(key);
+                    entry.count += 1;
+                }
+                // напісанне захоўваем сырым: «школа » з хвастовым прабелам — асобны
+                // радок у базе, і без яго адбор па тэгу згубіць частку слоў
+                entry.spellings.add(raw);
+            }
+        }
+        if (data.length < step) {
+            break;
+        }
+    }
+    tagUsage.value = usage;
+};
+
+// «Мова» і «мова» — адзін тэг, разрэзаны напалам розным напісаннем.
+// Шукаем адразу па ўсіх напісаннях, каб склеіць яго на экране.
+const applyTagFilter = (query) => {
+    if (!tagQuery) {
+        return query;
+    }
+    const spellings = tagUsage.value?.get(tagQuery.toLowerCase())?.spellings;
+    const list = spellings ? [...spellings] : [tagQuery];
+    return query.or(list.map((name) => 'tags.cs.' + JSON.stringify([name])).join(','));
+};
 const terms = ref(null);
 const count = ref(0);
 const account = ref();
@@ -203,8 +297,9 @@ const buildIds = async (mode) => {
             .select('definition_id, created_at, vote_result')
             .range(from, from + step - 1);
         if (searchQuery) {
-            idQuery = idQuery.filter('name', 'ilike', `%${searchQuery}%`);
+            idQuery = idQuery.filter('term', 'ilike', `%${searchQuery}%`);
         }
+        idQuery = applyTagFilter(idQuery);
         const { data, error } = await idQuery;
         if (error) {
             throw error;
@@ -255,8 +350,10 @@ const fetchTerms = async () => {
     queryBuilder = queryBuilder.order('created_at', { ascending: false });
 
     if (searchQuery) {
-        queryBuilder = queryBuilder.filter('name', 'ilike', `%${searchQuery}%`);
+        queryBuilder = queryBuilder.filter('term', 'ilike', `%${searchQuery}%`);
     }
+
+    queryBuilder = applyTagFilter(queryBuilder);
 
     let { data, error, count: termsCount } = await queryBuilder;
 
@@ -273,6 +370,14 @@ watch(sort, () => {
 
 onMounted(async () => {
     account.value = await getUser();
+    // Лічыльнік патрэбны і для колеру тэгаў, і для пошуку па ўсіх напісаннях,
+    // таму чакаем яго да першай выбаркі. Але калі ён не загрузіцца — гэта не падстава
+    // хаваць увесь спіс слоў: без яго тэгі проста застаюцца звычайнымі спасылкамі.
+    try {
+        await loadTagUsage();
+    } catch (error) {
+        console.error(error);
+    }
     await fetchTerms();
 });
 </script>

--- a/src/router.js
+++ b/src/router.js
@@ -253,7 +253,21 @@ const routes = [...main];
 const router = createRouter({
     history: createWebHistory(),
     routes,
-    scrollBehavior: () => ({ top: 0, behavior: 'smooth' }),
+    // Пры пераходзе назад вяртаем чалавека туды, дзе ён чытаў, а не наверх старонкі.
+    // Чакаем, пакуль спіс загрузіцца і старонка вырасце: інакш аднаўляць месца няма куды —
+    // браўзер прокруціць да канца кароткай старонкі і спыніцца.
+    scrollBehavior: async (to, from, savedPosition) => {
+        if (!savedPosition) {
+            return { top: 0, behavior: 'smooth' };
+        }
+        for (let i = 0; i < 20; i++) {
+            if (document.documentElement.scrollHeight >= savedPosition.top + window.innerHeight) {
+                break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        return savedPosition;
+    },
 });
 router.beforeEach((to) => {
     document.title = to.meta && to.meta.title ? `${to.meta.title} - Нішо` : 'Нішо';


### PR DESCRIPTION
Clicking a tag now shows the other words carrying it, and a chip beside the sort control says which tag is filtering the list.

Green means the tag is worth following. Grey means this is the only word that has it, so it is not a link at all — no pointer, no response to the cursor. The click would have landed you back on the word you came from.

Measured against the live data before choosing this: of 626 tags, 358 (57%) are used exactly once, and one in six tag appearances on a card is such a dead end. Frequent enough to be worth marking rather than letting people find out by clicking.

Green tags shrink slightly under the cursor and a little more on press, rather than growing — tags sit 4px apart and one that grew would crowd its neighbours.

The chip is the same green pill the cards use, not a separate style. It sits to the left of the sort control on the same line, with a hairline between the word and its cross running the full height of the pill. A long tag wraps below the sort rather than above it — hence the reversed flex order, which is what decides which of the two moves down.

**Dismissing the chip returns you where you were**

It goes back in history rather than building a fresh URL, so the page, the sort and the reading position all come back. scrollBehavior honours savedPosition for that and waits for the list to load before restoring — otherwise the page is still short and there is nowhere to scroll to. This makes browser Back restore the reading position everywhere, not only for tags.

**Counting happens in the browser: deliberate, and temporary**

The page fetches every word's tags once per visit — about 57 KB at today's 904 words — and counts there. Nothing is stored, so a tag turns green by itself once a second word gets it and no counter can drift out of step with the data. A stored counter would have to be updated on every add, edit, untag and delete, and the first missed path would leave a tag green with one word behind it.

For a much larger dictionary this belongs in the database — as a computed field in the view, again not as a stored counter. If the request fails the word list still renders and the tags stay plain links: colouring is decoration and must not take the content down with it.

**Two data problems worked around while we are not touching the database**

Twenty-seven tags exist under more than one spelling — capitals ("мат" / "Мат") or a trailing space ("школа" / "школа "). Following a tag searches all of its spellings at once, so "Школа" returns all 12 words rather than the 1 under that exact casing.

Twenty-four words (2.7%) carry duplicate tags: definition_tag holds repeated rows for the same pair and nothing prevents it — "Лузік!" has 13 links for 2 distinct tags. Cards collapse repeats on display. The real fix is a unique constraint plus a one-time cleanup, which needs database access.

**Also fixes a bug that predates this**

Searching the word list filtered on terms.name, but the view exposes the word as terms.term — the query returned a 400 and the page came up empty. It only affected pressing Enter without picking a suggestion, which is why it went unnoticed.