### PR TITLE
Rename "Апісанне" to "Пра праект"

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,7 +5,7 @@
         <priority>1.0</priority>
     </url>
     <url>
-        <loc>https://nisho.me/apisanne</loc>
+        <loc>https://nisho.me/pra-praekt</loc>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>

--- a/src/DefaultLayout.vue
+++ b/src/DefaultLayout.vue
@@ -16,7 +16,7 @@
                 </a>
             </div>
             <div class="about-links">
-                <router-link :to="{ name: 'about' }">Апісанне</router-link>
+                <router-link :to="{ name: 'about' }">Пра праект</router-link>
                 <router-link :to="{ name: 'team' }">Каманда</router-link>
                 <router-link :to="{ name: 'donation' }">Заданаціць</router-link>
                 <router-link :to="{ name: 'contacts' }">Кантакты</router-link>

--- a/src/Navbar.vue
+++ b/src/Navbar.vue
@@ -80,7 +80,7 @@
             <template #dropdown>
                 <el-dropdown-menu class="hamburger-dropdown">
                     <el-dropdown-item>
-                        <router-link :to="{ name: 'about' }">Апісанне</router-link>
+                        <router-link :to="{ name: 'about' }">Пра праект</router-link>
                     </el-dropdown-item>
                     <el-dropdown-item>
                         <router-link :to="{ name: 'team' }">Каманда</router-link>

--- a/src/router.js
+++ b/src/router.js
@@ -59,7 +59,7 @@ const main = [
         ],
     },
     {
-        path: '/apisanne',
+        path: '/pra-praekt',
         component: DefaultLayout,
         children: [
             {
@@ -68,6 +68,12 @@ const main = [
                 component: About,
             },
         ],
+    },
+    // Старая адраса старонкі. Яна стаіць у sitemap і можа быць у чужых спасылках,
+    // таму не выкідаем яе, а вядзём на новую — інакш усе ранейшыя спасылкі трапяць у 404.
+    {
+        path: '/apisanne',
+        redirect: { name: 'about' },
     },
     {
         path: '/kamanda',


### PR DESCRIPTION
"Апісанне" on its own does not say a description of what. The menu item and the footer link now read "Пра праект".

The page URL changes with it, /apisanne to /pra-praekt, and the old one redirects rather than disappearing: it is listed in sitemap.xml and may be linked from outside, so dropping it would send every existing link to the 404 page. The redirect sits before the catch-all route — after it, the catch-all would swallow the old path first.

Nothing else had to change. Every link inside the site targets the route by name rather than by path, so they all followed on their own; the only two places the path appeared at all were the router and the sitemap.

The sitemap now points at the new URL so search engines move over to it as the canonical one. Keep the redirect: it is part of the agreement with whoever already linked to the old address.