### PR TITLE
Tag input: one hint, no duplicates, kinder wording

### DIFF
--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -248,6 +248,9 @@ button {
     --el-input-bg-color: rgba(234, 234, 234, 1);
     --el-input-border-color: rgba(234, 234, 234, 1);
     --el-input-border-radius: 0.5rem;
+    /* колер рамкі ў спакоі тут ужо шэры, а рамку ПРЫ ФОКУСЕ Element Plus фарбуе
+       ў свой сіні #409eff — задаем і яе, інакш поле сінее ад аднаго курсора */
+    --el-input-focus-border-color: rgba(234, 234, 234, 1);
 
     padding: 1px 1rem;
 }
@@ -262,6 +265,7 @@ button {
 .complaint_form .el-textarea {
     --el-input-bg-color: rgba(234, 234, 234, 1);
     --el-input-border-color: rgba(234, 234, 234, 1);
+    --el-input-focus-border-color: rgba(234, 234, 234, 1);
 }
 .add-word_form .el-textarea__inner,
 .login_form .el-textarea__inner,
@@ -302,6 +306,7 @@ button {
 }
 
 .add-word__tags-input-wrapper {
+    position: relative;
     width: 100%;
     background-color: rgba(234, 234, 234, 1);
     border-radius: 0.5rem;
@@ -331,9 +336,52 @@ button {
     min-width: 15rem;
 }
 
-.add-word__tags-input.el-input--large .el-input__wrapper {
+.add-word__tags-input .el-input__wrapper {
     background-color: transparent;
     padding: 0.5rem 1rem;
+}
+
+/* Element Plus малюе вакол поля цень-абводку, а пры фокусе перафарбоўвае яе ў свой
+   сіні #409eff — колер, якога ў нашай палітры няма. Поле і так відаць па шэрай
+   падкладцы, таму абводка не патрэбная: дастаткова курсора. */
+.add-word__tags-input .el-input__wrapper,
+.add-word__tags-input .el-input__wrapper:hover,
+.add-word__tags-input .el-input__wrapper.is-focus {
+    box-shadow: none;
+}
+
+/* Адна падказка над полем, як у месенджарах: або дакрануўся, або пішаш далей міма.
+   Шэрая, а не зялёная, — гэта яшчэ не дададзены тэг, а прапанова. */
+.tag-hint {
+    position: absolute;
+    bottom: 100%;
+    left: 1rem;
+    margin-bottom: 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    background-color: white;
+    border-radius: 1.25rem;
+    box-shadow: 0 2px 8px rgba(107, 90, 135, 0.25);
+    font-size: 1.25rem;
+    color: #494949;
+    z-index: 1;
+}
+
+.tag-hint__accept {
+    background: none;
+    cursor: pointer;
+    color: inherit;
+    font: inherit;
+    padding: 0.5rem 0.5rem 0.5rem 1rem;
+}
+
+.tag-hint__dismiss {
+    background: none;
+    cursor: pointer;
+    color: #868686;
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0.5rem 1rem 0.5rem 0.5rem;
 }
 
 .password_input {

--- a/src/Add.vue
+++ b/src/Add.vue
@@ -14,8 +14,8 @@
             Усе тлумачэнні ў Нішо напісаныя звычайнымі людзьмі. Ты таксама можаш дадаць у слоўнік свае.
             <br />
             Зазірні ў
-            <router-link :to="{ name: 'rules' }" target="_blank">гайдлайны</router-link>
-            перад тым як даваць новаe слова ці яго тлумачэнне.
+            <router-link :to="{ name: 'rules' }" target="_blank">правілы</router-link>
+            перад тым як даваць новае слова ці яго тлумачэнне.
         </p>
         <el-form-item label="Слова:" prop="term_name">
             <el-input v-model="new_term.term_name" />
@@ -39,11 +39,28 @@
                 >
                     {{ tag }}
                 </el-tag>
+                <span v-if="tagHint" class="tag-hint">
+                    <!-- mousedown.prevent: без гэтага поле губляе фокус раней за націск,
+                         спрацоўвае @blur і паспявае дадаць недапісанае «раз» побач з «размоўнае» -->
+                    <button class="tag-hint__accept" type="button" @mousedown.prevent @click="acceptTagHint">
+                        {{ tagHint }}
+                    </button>
+                    <button
+                        class="tag-hint__dismiss"
+                        type="button"
+                        title="Схаваць падказку"
+                        @mousedown.prevent
+                        @click="dismissTagHint"
+                    >
+                        ×
+                    </button>
+                </span>
                 <el-input
                     v-model="newTag"
                     ref="newTagInput"
                     size="large"
                     class="add-word__tags-input"
+                    @input="refreshTagHint"
                     @keydown.enter.prevent="handleAddTag"
                     @blur="handleAddTag"
                 />
@@ -76,34 +93,36 @@ const rules = reactive({
     term_name: [
         {
             required: true,
-            message: 'Слова павінна быць не меньш 3 сымбалеў',
+            message: 'Напішы слова — хаця б дзве літары',
             trigger: 'blur',
         },
         {
-            min: 3,
-            message: 'Слова павінна быць не меньш 3 сымбалеў',
+            // База дазваляе слова ад дзвюх літар (constraint valid_name у schema.sql).
+            // Форма патрабавала тры — і не пускала абрэвіятуры кшталту «ШІ».
+            min: 2,
+            message: 'Напішы слова — хаця б дзве літары',
             trigger: 'blur',
         },
     ],
     definition: [
         {
             required: true,
-            message: 'Павінна быць змястоўнае тлумачэнне',
+            message: 'Змястоўна патлумач слова',
             trigger: 'blur',
         },
         {
             min: 10,
-            message: 'Павінна быць змястоўнае тлумачэнне',
+            message: 'Змястоўна патлумач слова',
             trigger: 'blur',
         },
     ],
     example: [
         {
             required: true,
-            message: 'Павінен быць змястоўны прыклад',
+            message: 'Дадай прыклад ужывання',
             trigger: 'blur',
         },
-        { min: 10, message: 'Павінен быць змястоўны прыклад', trigger: 'blur' },
+        { min: 10, message: 'Дадай прыклад ужывання', trigger: 'blur' },
     ],
 });
 const form = ref();
@@ -140,12 +159,94 @@ const handleRemoveTag = (tag) => {
     new_term.tags.splice(new_term.tags.indexOf(tag), 1);
 };
 
+// Падказка пра ўжо існы тэг: адна, над полем. Чалавек або дакранаецца да яе,
+// або проста піша далей і не заўважае.
+const tagHint = ref('');
+const hintDismissedFor = ref('');
+let hintTimer = null;
+
+// Выбіраем адзін варыянт, а не спіс: той, што пачынаецца з набранага, і найкарацейшы.
+// Такі найбліжэй да таго, што чалавек, відаць, дапісвае.
+const pickHint = (names, query) => {
+    const lowerQuery = query.toLowerCase();
+    const already = new Set(new_term.tags.map((tag) => tag.trim().toLowerCase()));
+    const seen = new Map();
+
+    for (const name of names) {
+        const key = name.trim().toLowerCase();
+
+        if (already.has(key) || key === lowerQuery) {
+            continue;
+        }
+
+        // «Мова» і «мова» — адзін тэг; трымаем напісанне без лішніх прабелаў і ў ніжнім рэгістры
+        if (!seen.has(key) || name === name.trim().toLowerCase()) {
+            seen.set(key, name.trim());
+        }
+    }
+
+    const candidates = [...seen.entries()];
+    const starts = candidates.filter(([key]) => key.startsWith(lowerQuery));
+    const pool = starts.length ? starts : candidates;
+
+    pool.sort((a, b) => a[0].length - b[0].length);
+
+    return pool.length ? pool[0][1] : '';
+};
+
+const refreshTagHint = () => {
+    clearTimeout(hintTimer);
+
+    const query = newTag.value.trim();
+
+    if (!query || query === hintDismissedFor.value) {
+        tagHint.value = '';
+        return;
+    }
+
+    // не б'ём у базу на кожную літару
+    hintTimer = setTimeout(async () => {
+        const { data, error } = await supabase.from('tag').select('name').ilike('name', `%${query}%`).limit(20);
+
+        if (error || newTag.value.trim() !== query) {
+            return;
+        }
+
+        tagHint.value = pickHint(
+            data.map((row) => row.name),
+            query
+        );
+    }, 200);
+};
+
+const acceptTagHint = () => {
+    newTag.value = tagHint.value;
+    tagHint.value = '';
+    handleAddTag();
+};
+
+const dismissTagHint = () => {
+    hintDismissedFor.value = newTag.value.trim();
+    tagHint.value = '';
+};
+
 const handleAddTag = () => {
-    const normalizedValue = newTag.value.trim();
+    // Прыбіраем крайнія прабелы і сціскаем двайныя ўнутры. У базе праз гэта ўжо ляжаць
+    // асобна «школа» і «школа » — розныя радкі толькі з-за хвастовага прабелу.
+    const normalizedValue = newTag.value.trim().replace(/ +/g, ' ');
 
     if (!normalizedValue) return;
 
-    if (normalizedValue && !new_term.tags.includes(normalizedValue)) {
+    // «Мова» і «мова» — той самы тэг, таму параўноўваем без уліку рэгістра.
+    // Ранейшая праверка звярала напісанне дакладна і прапускала абодва ў адну картку.
+    const alreadyAdded = new_term.tags.find((tag) => tag.toLowerCase() === normalizedValue.toLowerCase());
+
+    if (alreadyAdded) {
+        // Моўчкі не дадаць — значыць пакінуць чалавека ў здагадках: поле ачысцілася,
+        // а тэг не з'явіўся. Называем тое напісанне, якое ўжо стаіць, каб было бачна,
+        // чаму «мова» не дадалася, калі ў картцы «Мова».
+        ElMessage.info(`«${alreadyAdded}» ужо ёсць`);
+    } else {
         new_term.tags.push(normalizedValue);
     }
 

--- a/src/Add.vue
+++ b/src/Add.vue
@@ -89,40 +89,34 @@ const new_term = reactive({
     example: '',
     tags: [],
 });
+// Даўжыню правяраем толькі тады, калі чалавек ужо нешта напісаў. Пустое поле —
+// гэта не памылка, а проста яшчэ не запоўненае: чырваніць яго загадзя няветліва.
+const minIfFilled = (length, text) => (rule, value, callback) => {
+    const written = (value || '').trim();
+
+    if (written && written.length < length) {
+        callback(new Error(text));
+        return;
+    }
+
+    callback();
+};
+
 const rules = reactive({
     term_name: [
-        {
-            required: true,
-            message: 'Напішы слова — хаця б дзве літары',
-            trigger: 'blur',
-        },
-        {
-            // База дазваляе слова ад дзвюх літар (constraint valid_name у schema.sql).
-            // Форма патрабавала тры — і не пускала абрэвіятуры кшталту «ШІ».
-            min: 2,
-            message: 'Напішы слова — хаця б дзве літары',
-            trigger: 'blur',
-        },
+        // trigger 'submit' у інтэрфейсе не бывае, таму правіла спрацуе толькі пры
+        // поўнай праверцы — гэта значыць пры націску «Гатова».
+        // Без trigger правіла лічыцца «правяраць заўсёды» і чырваніць пустое поле адразу.
+        { required: true, message: 'Напішы слова — хаця б дзве літары', trigger: 'submit' },
+        { validator: minIfFilled(2, 'Напішы слова — хаця б дзве літары'), trigger: 'blur' },
     ],
     definition: [
-        {
-            required: true,
-            message: 'Змястоўна патлумач слова',
-            trigger: 'blur',
-        },
-        {
-            min: 10,
-            message: 'Змястоўна патлумач слова',
-            trigger: 'blur',
-        },
+        { required: true, message: 'Змястоўна патлумач слова', trigger: 'submit' },
+        { validator: minIfFilled(10, 'Змястоўна патлумач слова'), trigger: 'blur' },
     ],
     example: [
-        {
-            required: true,
-            message: 'Дадай прыклад ужывання',
-            trigger: 'blur',
-        },
-        { min: 10, message: 'Дадай прыклад ужывання', trigger: 'blur' },
+        { required: true, message: 'Дадай прыклад ужывання', trigger: 'submit' },
+        { validator: minIfFilled(10, 'Дадай прыклад ужывання'), trigger: 'blur' },
     ],
 });
 const form = ref();

--- a/src/Edit.vue
+++ b/src/Edit.vue
@@ -93,40 +93,34 @@ const new_term = reactive({
     example: '',
     tags: [],
 });
+// Даўжыню правяраем толькі тады, калі чалавек ужо нешта напісаў. Пустое поле —
+// гэта не памылка, а проста яшчэ не запоўненае: чырваніць яго загадзя няветліва.
+const minIfFilled = (length, text) => (rule, value, callback) => {
+    const written = (value || '').trim();
+
+    if (written && written.length < length) {
+        callback(new Error(text));
+        return;
+    }
+
+    callback();
+};
+
 const rules = reactive({
     term_name: [
-        {
-            required: true,
-            message: 'Напішы слова — хаця б дзве літары',
-            trigger: 'blur',
-        },
-        {
-            // База дазваляе слова ад дзвюх літар (constraint valid_name у schema.sql).
-            // Форма патрабавала тры — і не пускала абрэвіятуры кшталту «ШІ».
-            min: 2,
-            message: 'Напішы слова — хаця б дзве літары',
-            trigger: 'blur',
-        },
+        // trigger 'submit' у інтэрфейсе не бывае, таму правіла спрацуе толькі пры
+        // поўнай праверцы — гэта значыць пры націску «Гатова».
+        // Без trigger правіла лічыцца «правяраць заўсёды» і чырваніць пустое поле адразу.
+        { required: true, message: 'Напішы слова — хаця б дзве літары', trigger: 'submit' },
+        { validator: minIfFilled(2, 'Напішы слова — хаця б дзве літары'), trigger: 'blur' },
     ],
     definition: [
-        {
-            required: true,
-            message: 'Змястоўна патлумач слова',
-            trigger: 'blur',
-        },
-        {
-            min: 10,
-            message: 'Змястоўна патлумач слова',
-            trigger: 'blur',
-        },
+        { required: true, message: 'Змястоўна патлумач слова', trigger: 'submit' },
+        { validator: minIfFilled(10, 'Змястоўна патлумач слова'), trigger: 'blur' },
     ],
     example: [
-        {
-            required: true,
-            message: 'Дадай прыклад ужывання',
-            trigger: 'blur',
-        },
-        { min: 10, message: 'Дадай прыклад ужывання', trigger: 'blur' },
+        { required: true, message: 'Дадай прыклад ужывання', trigger: 'submit' },
+        { validator: minIfFilled(10, 'Дадай прыклад ужывання'), trigger: 'blur' },
     ],
 });
 const form = ref();

--- a/src/Edit.vue
+++ b/src/Edit.vue
@@ -16,8 +16,8 @@
             Усе тлумачэнні ў Нішо напісаныя звычайнымі людзьмі. Ты таксама можаш дадаць у слоўнік свае.
             <br />
             Зазірні ў
-            <router-link :to="{ name: 'rules' }" target="_blank">гайдлайны</router-link>
-            перад тым як даваць новаe слова ці яго тлумачэнне.
+            <router-link :to="{ name: 'rules' }" target="_blank">правілы</router-link>
+            перад тым як даваць новае слова ці яго тлумачэнне.
         </p>
         <el-form-item label="Слова:" prop="term_name">
             <el-input v-model="new_term.term_name" disabled />
@@ -41,11 +41,28 @@
                 >
                     {{ tag }}
                 </el-tag>
+                <span v-if="tagHint" class="tag-hint">
+                    <!-- mousedown.prevent: без гэтага поле губляе фокус раней за націск,
+                         спрацоўвае @blur і паспявае дадаць недапісанае «раз» побач з «размоўнае» -->
+                    <button class="tag-hint__accept" type="button" @mousedown.prevent @click="acceptTagHint">
+                        {{ tagHint }}
+                    </button>
+                    <button
+                        class="tag-hint__dismiss"
+                        type="button"
+                        title="Схаваць падказку"
+                        @mousedown.prevent
+                        @click="dismissTagHint"
+                    >
+                        ×
+                    </button>
+                </span>
                 <el-input
                     v-model="newTag"
                     ref="newTagInput"
                     size="large"
                     class="add-word__tags-input"
+                    @input="refreshTagHint"
                     @keydown.enter.prevent="handleAddTag"
                     @blur="handleAddTag"
                 />
@@ -80,34 +97,36 @@ const rules = reactive({
     term_name: [
         {
             required: true,
-            message: 'Слова павінна быць не меньш 3 сымбалеў',
+            message: 'Напішы слова — хаця б дзве літары',
             trigger: 'blur',
         },
         {
-            min: 3,
-            message: 'Слова павінна быць не меньш 3 сымбалеў',
+            // База дазваляе слова ад дзвюх літар (constraint valid_name у schema.sql).
+            // Форма патрабавала тры — і не пускала абрэвіятуры кшталту «ШІ».
+            min: 2,
+            message: 'Напішы слова — хаця б дзве літары',
             trigger: 'blur',
         },
     ],
     definition: [
         {
             required: true,
-            message: 'Павінна быць змястоўнае тлумачэнне',
+            message: 'Змястоўна патлумач слова',
             trigger: 'blur',
         },
         {
             min: 10,
-            message: 'Павінна быць змястоўнае тлумачэнне',
+            message: 'Змястоўна патлумач слова',
             trigger: 'blur',
         },
     ],
     example: [
         {
             required: true,
-            message: 'Павінен быць змястоўны прыклад',
+            message: 'Дадай прыклад ужывання',
             trigger: 'blur',
         },
-        { min: 10, message: 'Павінен быць змястоўны прыклад', trigger: 'blur' },
+        { min: 10, message: 'Дадай прыклад ужывання', trigger: 'blur' },
     ],
 });
 const form = ref();
@@ -180,12 +199,94 @@ const handleRemoveTag = (tag) => {
     new_term.tags.splice(new_term.tags.indexOf(tag), 1);
 };
 
+// Падказка пра ўжо існы тэг: адна, над полем. Чалавек або дакранаецца да яе,
+// або проста піша далей і не заўважае.
+const tagHint = ref('');
+const hintDismissedFor = ref('');
+let hintTimer = null;
+
+// Выбіраем адзін варыянт, а не спіс: той, што пачынаецца з набранага, і найкарацейшы.
+// Такі найбліжэй да таго, што чалавек, відаць, дапісвае.
+const pickHint = (names, query) => {
+    const lowerQuery = query.toLowerCase();
+    const already = new Set(new_term.tags.map((tag) => tag.trim().toLowerCase()));
+    const seen = new Map();
+
+    for (const name of names) {
+        const key = name.trim().toLowerCase();
+
+        if (already.has(key) || key === lowerQuery) {
+            continue;
+        }
+
+        // «Мова» і «мова» — адзін тэг; трымаем напісанне без лішніх прабелаў і ў ніжнім рэгістры
+        if (!seen.has(key) || name === name.trim().toLowerCase()) {
+            seen.set(key, name.trim());
+        }
+    }
+
+    const candidates = [...seen.entries()];
+    const starts = candidates.filter(([key]) => key.startsWith(lowerQuery));
+    const pool = starts.length ? starts : candidates;
+
+    pool.sort((a, b) => a[0].length - b[0].length);
+
+    return pool.length ? pool[0][1] : '';
+};
+
+const refreshTagHint = () => {
+    clearTimeout(hintTimer);
+
+    const query = newTag.value.trim();
+
+    if (!query || query === hintDismissedFor.value) {
+        tagHint.value = '';
+        return;
+    }
+
+    // не б'ём у базу на кожную літару
+    hintTimer = setTimeout(async () => {
+        const { data, error } = await supabase.from('tag').select('name').ilike('name', `%${query}%`).limit(20);
+
+        if (error || newTag.value.trim() !== query) {
+            return;
+        }
+
+        tagHint.value = pickHint(
+            data.map((row) => row.name),
+            query
+        );
+    }, 200);
+};
+
+const acceptTagHint = () => {
+    newTag.value = tagHint.value;
+    tagHint.value = '';
+    handleAddTag();
+};
+
+const dismissTagHint = () => {
+    hintDismissedFor.value = newTag.value.trim();
+    tagHint.value = '';
+};
+
 const handleAddTag = () => {
-    const normalizedValue = newTag.value.trim();
+    // Прыбіраем крайнія прабелы і сціскаем двайныя ўнутры. У базе праз гэта ўжо ляжаць
+    // асобна «школа» і «школа » — розныя радкі толькі з-за хвастовага прабелу.
+    const normalizedValue = newTag.value.trim().replace(/ +/g, ' ');
 
     if (!normalizedValue) return;
 
-    if (normalizedValue && !new_term.tags.includes(normalizedValue)) {
+    // «Мова» і «мова» — той самы тэг, таму параўноўваем без уліку рэгістра.
+    // Ранейшая праверка звярала напісанне дакладна і прапускала абодва ў адну картку.
+    const alreadyAdded = new_term.tags.find((tag) => tag.toLowerCase() === normalizedValue.toLowerCase());
+
+    if (alreadyAdded) {
+        // Моўчкі не дадаць — значыць пакінуць чалавека ў здагадках: поле ачысцілася,
+        // а тэг не з'явіўся. Называем тое напісанне, якое ўжо стаіць, каб было бачна,
+        // чаму «мова» не дадалася, калі ў картцы «Мова».
+        ElMessage.info(`«${alreadyAdded}» ужо ёсць`);
+    } else {
         new_term.tags.push(normalizedValue);
     }
 


### PR DESCRIPTION
**A hint instead of a dropdown**

Typing a tag now shows a single suggestion above the field — the closest existing tag — which you either tap or type straight past. It replaces what you typed; its cross hides it and leaves your text alone.

A dropdown list was tried first and did not suit a phone. It stood 242px tall where a keyboard leaves about half the screen, its rows were 34px against the 44px a finger needs, and the floating donate button covered 19% of its width. The hint sits in the flow above the field, one line tall, and none of that applies. Its tap target is 48px.

Only one suggestion is offered, never the whole list, and spelling variants are collapsed: "Мова" and "мова" are one tag, so offering both would be asking the user to pick between the duplicates we are trying to remove. The kept spelling is the trimmed lowercase one, which is what the dictionary mostly uses.

The buttons take mousedown.prevent so the field never loses focus. Without it the blur handler fires first and commits the half-typed "раз" next to the chosen "размоўнае".

**No duplicate tags**

Adding compared spellings exactly, so "Мова" and "мова" both went into one card — and on into the database as separate rows, since tag.name is unique case-sensitively while terms are indexed on lower(name). The check is case-insensitive now, and the value is normalised: outer spaces trimmed, inner runs collapsed. Both problems exist in the data already — "школа" and "школа " differ by nothing but a trailing space.

If the tag is already on the card, a short note says so and names the spelling that is there, rather than clearing the field silently.

This stops new duplicates; it does not clean up the 27 pairs already in the data, which needs database access.

**Wording**

  Слова павінна быць не меньш 3 сымбалеў → Напішы слова — хаця б дзве літары
  Павінна быць змястоўнае тлумачэнне     → Змястоўна патлумач слова
  Павінен быць змястоўны прыклад         → Дадай прыклад ужывання

Verb first, addressed as "ты" like the note above the form, and no judgement of what the person wrote. Also fixes the "меньш" typo.

The link labelled "гайдлайны" opens the Rules page, so it now reads "правілы". And "новаe" contained a Latin "e" — invisible in Cyrillic text, but a different word to any search.

**The word may now be two letters**

The form demanded three, so abbreviations like "ШІ" were rejected. The database has always allowed two (constraint valid_name in schema.sql); the form was stricter than the data model for no reason. One is not possible — the database would refuse it, and the person would see an opaque save error instead of a hint.

**No blue left in the form**

Element Plus paints the focus ring with its own #409eff, a colour this palette does not contain. The form overrode the resting border colour but not the focused one, so every field turned blue the moment a caret entered it. Setting it where the library sets it — on the field, not on the form, which is too far up to win.

Not verified: the Edit page. The changes there are the same code, but it needs an existing word and rights to it, which a local stub cannot give. Worth a look on the preview.

3 files changed, +273 −23.