### PR TITLE
All-tags page: alphabetical cloud, popular tags larger

### DIFF
--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -825,6 +825,46 @@ a.user-tag:active {
     transform: scale(0.92);
 }
 
+/* воблака на старонцы «Усе тэгі»: словы рознага памеру, раўнуюцца па базавай лініі */
+.tag-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    column-gap: 0.625rem;
+    row-gap: 0.625rem;
+    padding-top: 8px;
+}
+
+/* тая ж пілюля, што тэг на картцы слова (фон, колер, радыус), толькі памеры
+   ў em — каб падушкі і скругленне раслі разам са шрыфтам */
+.tag-cloud__tag {
+    color: #494949;
+    text-decoration: none;
+    line-height: 1.25;
+    background: #9ffc70;
+    /* канцы заўсёды паўкруглыя, як у капсулы, пры любым памеры шрыфта */
+    border-radius: 999px;
+    padding: 0.25em 0.625em;
+    transition: transform 0.12s ease;
+}
+
+/* тэг, які мае толькі адно слова: святлейшы, з лёгкім градыентам */
+.tag-cloud__tag--single {
+    background: linear-gradient(180deg, #e4fab0 0%, #d6f897 100%);
+}
+
+.tag-cloud__tag:hover {
+    transform: scale(0.96);
+}
+
+.tag-cloud__tag:active {
+    transform: scale(0.92);
+}
+
+.tag-cloud__note {
+    color: #494949;
+}
+
 /* чып адбору — той самы тэг з карткі, толькі з крыжыкам */
 .sort-tag {
     display: inline-flex;

--- a/src/AllTags.vue
+++ b/src/AllTags.vue
@@ -1,0 +1,135 @@
+<template>
+    <div class="main-container container">
+        <div class="cards-div">
+            <div class="card">
+                <h2>Усе тэгі</h2>
+
+                <p v-if="loading" class="tag-cloud__note">Збіраем тэгі…</p>
+                <p v-else-if="failed" class="tag-cloud__note">
+                    Не атрымалася загрузіць тэгі. Паспрабуй абнавіць старонку.
+                </p>
+
+                <div v-else class="tag-cloud">
+                    <router-link
+                        v-for="tag in cloud"
+                        :key="tag.key"
+                        class="tag-cloud__tag"
+                        :class="{ 'tag-cloud__tag--single': tag.count === 1 }"
+                        :style="{ fontSize: tag.size + 'rem' }"
+                        :title="tag.count + ' ' + wordsLabel(tag.count)"
+                        :to="{ name: 'terms', query: { tag: tag.name } }"
+                    >
+                        {{ tag.name }}
+                    </router-link>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { supabase } from './supabase.js';
+
+const loading = ref(true);
+const failed = ref(false);
+const usage = ref(new Map());
+
+// Той самы падлік, што на галоўнай фарбуе тэгі ў шэры/зялёны: забіраем тэгі
+// ўсіх слоў і лічым у браўзеры. Часовае рашэнне, пакуль слоў мала, — пры
+// дзясятках тысяч слоў лічыць трэба будзе ў базе.
+const loadTagUsage = async () => {
+    const counted = new Map();
+    const step = 1000;
+    for (let from = 0; ; from += step) {
+        const { data, error } = await supabase
+            .from('terms')
+            .select('tags')
+            .range(from, from + step - 1);
+        if (error) {
+            throw error;
+        }
+        for (const row of data) {
+            const seen = new Set();
+            for (const raw of row.tags || []) {
+                const key = raw.trim().toLowerCase();
+                if (!key) {
+                    continue;
+                }
+                if (!counted.has(key)) {
+                    counted.set(key, { count: 0, spellings: new Set() });
+                }
+                const entry = counted.get(key);
+                // слова лічым адзін раз, нават калі тэг паўтараецца ў ім некалькі разоў
+                if (!seen.has(key)) {
+                    seen.add(key);
+                    entry.count += 1;
+                }
+                entry.spellings.add(raw);
+            }
+        }
+        if (data.length < step) {
+            break;
+        }
+    }
+    usage.value = counted;
+};
+
+// «Мова» і «мова » — адзін тэг з рознымі напісаннямі; паказваем адно,
+// аддаючы перавагу акуратнаму малому напісанню без хвастовых прабелаў
+const displayName = (key, spellings) => {
+    for (const raw of spellings) {
+        if (raw === key) {
+            return raw;
+        }
+    }
+    return [...spellings][0].trim();
+};
+
+// Памер расце як лагарыфм колькасці слоў: раз ад разу розніца прыкметная,
+// але тэг з сотняй слоў не засланяе сабой паўстаронкі
+const cloud = computed(() => {
+    const entries = [...usage.value.entries()];
+    if (!entries.length) {
+        return [];
+    }
+    const maxCount = Math.max(...entries.map(([, entry]) => entry.count));
+    const maxLog = Math.log(maxCount + 1);
+
+    return entries
+        .map(([key, entry]) => ({
+            key,
+            name: displayName(key, entry.spellings),
+            count: entry.count,
+            size: 0.875 + (Math.log(entry.count + 1) / maxLog) * 1.125,
+        }))
+        .sort((a, b) => a.key.localeCompare(b.key, 'be'));
+});
+
+const wordsLabel = (count) => {
+    const tens = count % 100;
+    const ones = count % 10;
+    if (tens >= 11 && tens <= 14) {
+        return 'слоў';
+    }
+    if (ones === 1) {
+        return 'слова';
+    }
+    if (ones >= 2 && ones <= 4) {
+        return 'словы';
+    }
+    return 'слоў';
+};
+
+onMounted(async () => {
+    try {
+        await loadTagUsage();
+    } catch (error) {
+        console.error(error);
+        failed.value = true;
+    }
+    loading.value = false;
+});
+</script>
+
+<style scoped></style>

--- a/src/Navbar.vue
+++ b/src/Navbar.vue
@@ -95,6 +95,9 @@
                         <router-link :to="{ name: 'rules' }">Правілы</router-link>
                     </el-dropdown-item>
                     <el-dropdown-item>
+                        <router-link :to="{ name: 'all-tags' }">Усе тэгі</router-link>
+                    </el-dropdown-item>
+                    <el-dropdown-item>
                         <router-link :to="{ name: 'bugs' }">Багі</router-link>
                     </el-dropdown-item>
                     <el-dropdown-item>

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Terms from './Terms.vue';
+import AllTags from './AllTags.vue';
 import Term from './Term.vue';
 import About from './About.vue';
 import Team from './Team.vue';
@@ -66,6 +67,17 @@ const main = [
                 name: 'about',
                 path: '',
                 component: About,
+            },
+        ],
+    },
+    {
+        path: '/tehi',
+        component: DefaultLayout,
+        children: [
+            {
+                name: 'all-tags',
+                path: '',
+                component: AllTags,
             },
         ],
     },


### PR DESCRIPTION
A new «Усе тэгі» page (first item in the burger menu) lists every tag in Belarusian alphabetical order, sized by how many words carry it — log scale, so a hundred-word tag stands out without drowning the page. Every tag links to the word list filtered by it; hovering shows the word count. Spelling variants («Мова», «мова », …) are counted as one tag and shown once.

Counting reuses the same browser-side approach as the word list's grey/green tags — fine while the dictionary is small. Display logic only, no database changes.