### PR TITLE
Author click filters the main list, full cards

### DIFF
--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -873,6 +873,37 @@ a.user-tag:active {
     color: #494949;
 }
 
+/* адбор па аўтары: белая капсула з @нікам — тая ж форма, што ў тэгаў,
+   але белая: аўтар — не тэг */
+.sort-autar {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    background: #fff;
+    color: #494949;
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem;
+}
+
+/* крыжык — як у чыпа тэга: рыска на ўсю вышыню капсулы і × па цэнтры.
+   Адмоўныя водступы даязджаюць да краёў вертыкальных палёў капсулы (0.25rem)
+   і дабіраюць іх сваімі, каб рыска ішла ад краю да краю */
+.sort-autar__close {
+    background: none;
+    cursor: pointer;
+    color: inherit;
+    font-size: 1.25rem;
+    line-height: 1;
+    border-left: 1px solid currentColor;
+    margin-top: -0.25rem;
+    margin-bottom: -0.25rem;
+    padding: 0.25rem 0 0.25rem 0.375rem;
+}
+
+.sort-autar__close:hover {
+    opacity: 0.7;
+}
+
 .sort-tag__close {
     background: none;
     cursor: pointer;
@@ -1105,6 +1136,8 @@ a.user-tag:active {
 @media screen and (max-width: 992px) {
     .sort-settings {
         margin-top: 1rem;
+        /* поле пошуку стаіць з водступам 1rem ад краю — чып аўтара раўнуем па ім */
+        margin-left: 1rem;
     }
     .header-logo-btn {
         padding-left: 1rem;

--- a/src/Terms.vue
+++ b/src/Terms.vue
@@ -19,6 +19,14 @@
                 {{ tagQuery }}
                 <button class="sort-tag__close" type="button" title="Зняць адбор па тэгу" @click="clearTag">×</button>
             </span>
+
+            <!-- аўтар — не тэг, таму без зялёнай пілюлі: белы надпіс, як у сартавання -->
+            <span v-if="autarQuery" class="sort-autar">
+                @{{ autarName }}
+                <button class="sort-autar__close" type="button" title="Зняць адбор па аўтары" @click="clearAutar">
+                    ×
+                </button>
+            </span>
         </div>
         <PageContentSpinner v-if="!terms" />
         <div v-else class="cards-div">
@@ -45,10 +53,12 @@
                     </template>
                 </div>
                 <div class="card-info">
+                    <!-- адбор па аўтары: тыя ж поўныя карткі, што і на галоўнай,
+                         а не ўціснуты спіс старонкі «Мае словы» -->
                     <router-link
                         :to="{
-                            name: 'user-words',
-                            params: { id: item.user.user_id },
+                            name: 'terms',
+                            query: { autar: item.user.user_id },
                         }"
                         class="card-info_link"
                     >
@@ -148,6 +158,7 @@ const router = useRouter();
 const route = useRoute();
 const searchQuery = route.query.poshuk?.trim();
 const tagQuery = route.query.tag?.trim();
+const autarQuery = route.query.autar?.trim();
 
 const clearTag = () => {
     // чалавек прыйшоў сюды з нейкага месца спісу — вяртаем яго туды, разам са
@@ -159,6 +170,16 @@ const clearTag = () => {
     }
     const query = { ...route.query };
     delete query.tag;
+    router.push({ name: 'terms', query });
+};
+
+const clearAutar = () => {
+    if (window.history.state?.back) {
+        router.back();
+        return;
+    }
+    const query = { ...route.query };
+    delete query.autar;
     router.push({ name: 'terms', query });
 };
 
@@ -234,6 +255,16 @@ const applyTagFilter = (query) => {
     const list = spellings ? [...spellings] : [tagQuery];
     return query.or(list.map((name) => 'tags.cs.' + JSON.stringify([name])).join(','));
 };
+// у чып бярэм імя з першай карткі — усе яны аднаго аўтара
+const autarName = computed(() => terms.value?.[0]?.user?.name || 'аўтар');
+
+const applyAutarFilter = (query) => {
+    if (!autarQuery) {
+        return query;
+    }
+    return query.eq('user->>user_id', autarQuery);
+};
+
 const terms = ref(null);
 const count = ref(0);
 const account = ref();
@@ -300,6 +331,7 @@ const buildIds = async (mode) => {
             idQuery = idQuery.filter('term', 'ilike', `%${searchQuery}%`);
         }
         idQuery = applyTagFilter(idQuery);
+        idQuery = applyAutarFilter(idQuery);
         const { data, error } = await idQuery;
         if (error) {
             throw error;
@@ -354,6 +386,7 @@ const fetchTerms = async () => {
     }
 
     queryBuilder = applyTagFilter(queryBuilder);
+    queryBuilder = applyAutarFilter(queryBuilder);
 
     let { data, error, count: termsCount } = await queryBuilder;
 


### PR DESCRIPTION
Clicking an author's name on a card used to lead to the condensed list built for «Мае словы». Now it filters the main page by that author instead — the same full cards, with a removable chip next to the sort control, matching how the tag filter works. The author filter survives sort changes and combines with the tag filter. «Мае словы» itself and the author link on a word's own page are unchanged.

Display logic only, no database changes.