### PR TITLE
Trim trailing blank lines when showing definitions and examples

### DIFF
--- a/src/Term.vue
+++ b/src/Term.vue
@@ -7,10 +7,10 @@
                     {{ item.term }}
                 </router-link>
                 <div class="card-description">
-                    {{ item.definition }}
+                    {{ tidy(item.definition) }}
                 </div>
                 <div class="card-example">
-                    {{ item.example }}
+                    {{ tidy(item.example) }}
                 </div>
                 <div class="card-tags">
                     <span class="user-tag" v-for="tag of item.tags">
@@ -124,6 +124,10 @@ const update = async (definition, type) => {
     await vote(definition, type);
     await fetchTerm();
 };
+
+// людзі часам пакідаюць пустыя радкі напрыканцы тэксту, і картка расце ўвысь
+// упустую (white-space: pre-wrap іх паказвае). Абразаем краі пры паказе.
+const tidy = (text) => (text || '').trim();
 
 const definitions = ref(null);
 const count = ref(0);

--- a/src/Terms.vue
+++ b/src/Terms.vue
@@ -31,10 +31,10 @@
                     {{ item.term }}
                 </router-link>
                 <div class="card-description">
-                    {{ item.definition }}
+                    {{ tidy(item.definition) }}
                 </div>
                 <div class="card-example">
-                    {{ item.example }}
+                    {{ tidy(item.example) }}
                 </div>
                 <div class="card-tags">
                     <template v-for="tag of uniqueTags(item.tags)" :key="tag">
@@ -234,6 +234,10 @@ const applyTagFilter = (query) => {
     const list = spellings ? [...spellings] : [tagQuery];
     return query.or(list.map((name) => 'tags.cs.' + JSON.stringify([name])).join(','));
 };
+// людзі часам пакідаюць пустыя радкі напрыканцы тэксту, і картка расце ўвысь
+// упустую (white-space: pre-wrap іх паказвае). Абразаем краі пры паказе.
+const tidy = (text) => (text || '').trim();
+
 const terms = ref(null);
 const count = ref(0);
 const account = ref();


### PR DESCRIPTION
People sometimes leave empty lines at the end of a definition or example, and white-space: pre-wrap faithfully renders them — the card grows tall for nothing. Trim the edges of both fields at display time, on the main list and on the word page. The stored text is untouched.

Display logic only, no database changes.