### PR TITLE
Grey hints inside the add-word form fields

### DIFF
--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -308,16 +308,37 @@ button {
 .add-word__tags-input-wrapper {
     position: relative;
     width: 100%;
+    box-sizing: border-box;
     background-color: rgba(234, 234, 234, 1);
     border-radius: 0.5rem;
     display: flex;
     align-items: center;
     flex-wrap: wrap;
+    /* адступ ад вугла — той жа, што ў тэксту ў іншых палях */
+    padding: 0.5rem 1rem;
+    gap: 0.5rem;
+}
+
+/* крыжык выдалення — як у чыпа адбору: рыска на ўсю вышыню пілюлі і × за ёй */
+.add-word__tags-input-tag .el-tag__close {
+    margin-left: 0.5rem;
+    margin-right: 0;
+    border-left: 1px solid currentColor;
+    border-radius: 0;
+    height: 100%;
+    width: auto;
+    padding-left: 0.5rem;
+    color: inherit;
+}
+
+.add-word__tags-input-tag .el-tag__close:hover {
+    background: none;
+    color: inherit;
+    opacity: 0.7;
 }
 
 .add-word__tags-input-tag {
-    margin-left: 1rem;
-    margin-top: 0.25rem;
+    margin: 0;
 }
 
 .add-word__tags-input-tag.el-tag {
@@ -331,14 +352,15 @@ button {
 }
 
 .add-word__tags-input.el-input {
-    width: auto;
-    flex-grow: 1;
-    min-width: 15rem;
+    /* базавая шырыня маленькая, каб набор працягваўся побач з пілюляй,
+       а не з новага радка; расце на ўсё вольнае месца */
+    flex: 1 1 6rem;
+    min-width: 6rem;
 }
 
 .add-word__tags-input .el-input__wrapper {
     background-color: transparent;
-    padding: 0.5rem 1rem;
+    padding: 0;
 }
 
 /* Element Plus малюе вакол поля цень-абводку, а пры фокусе перафарбоўвае яе ў свой
@@ -1405,4 +1427,61 @@ a.user-tag:active {
     .header-form .el-input__wrapper {
         padding-left: 0.25rem;
     }
+    /* загаловак старонкі роўна па тэксце ўнутры белай формы (у яе бакавыя
+       палі 1.3rem), а не ўпрытык да краю экрана */
+    .title {
+        text-align: left;
+        padding: 0 1.3rem;
+        margin: 1.5rem 0;
+    }
+}
+
+/* адзін памер тэксту ва ўсіх палях формы: аднарадковыя палі (слова, тэг)
+   без гэтага буйнейшыя за тэкставыя (24px супраць 19.2px) */
+.add-word_form .el-input__inner {
+    font-size: 1.2rem;
+}
+
+/* поле тэгаў вышэйшае — на два радкі: каб падказка змяшчалася цалкам */
+.add-word__tags-input-wrapper {
+    min-height: 4.75rem;
+    /* набор пачынаецца ўверсе поля, там, дзе і падказка */
+    align-content: flex-start;
+}
+
+/* тэкст не ліпне да верху: у тэкставых палях было 5px, робім аднолькава з усімі */
+.add-word_form .el-textarea__inner {
+    padding: 0.75rem 1rem;
+}
+
+/* свая падказка ўнутры поля тэгаў: шэрая, як у астатніх палях, умее пераносіцца.
+   Па кліку поле ловіць фокус самім wrapper'ам, таму падказцы клікі не патрэбныя */
+.tags-placeholder {
+    position: absolute;
+    /* радок уводу ўнутры мае вышыню 2.5rem і цэнтруе тэкст; ставім падказку так,
+       каб яе першы радок супаў з узроўнем набору */
+    top: 1.5rem;
+    left: 1rem;
+    right: 1rem;
+    /* палі ўжо ў самога поля; падказка стаіць ад таго ж вугла */
+    font-size: 1.2rem;
+    color: #a8abb2;
+    line-height: 1.4;
+    pointer-events: none;
+}
+
+
+/* «ужо ёсць» — побач з полем тэгаў, а не ўсплыўшы наверсе экрана */
+.tags-notice {
+    margin: 0.375rem 0 0;
+    font-size: 1.2rem;
+    color: #494949;
+    line-height: 1.4;
+}
+
+/* спасылка ўнутры падказкі жывая, хоць сама падказка клікі прапускае */
+.tags-placeholder__link {
+    color: #9442ce;
+    text-decoration: none;
+    pointer-events: auto;
 }

--- a/src/Add.vue
+++ b/src/Add.vue
@@ -15,19 +15,37 @@
             <br />
             Зазірні ў
             <router-link :to="{ name: 'rules' }" target="_blank">правілы</router-link>
-            перад тым як даваць новае слова ці яго тлумачэнне.
+            перад тым як даваць новае слова ці яго тлумачэнне. Зазірні ва
+            <!-- новая ўкладка: пераход пасярод запаўнення згубіў бы форму -->
+            <router-link :to="{ name: 'all-tags' }" target="_blank">Усе тэгі</router-link>
+            каб натхніцца.
         </p>
         <el-form-item label="Слова:" prop="term_name">
-            <el-input v-model="new_term.term_name" />
+            <el-input v-model="new_term.term_name" placeholder="Напішы слова" />
         </el-form-item>
         <el-form-item label="Тлумачэнне:" prop="definition">
-            <el-input v-model="new_term.definition" type="textarea" :rows="5" />
+            <el-input
+                v-model="new_term.definition"
+                type="textarea"
+                :rows="5"
+                placeholder="Дай азначэнне свайму слову. Паспрабуй напісаць яго як мага больш нейтральна і зразумела."
+            />
         </el-form-item>
         <el-form-item label="Прыклад:" prop="example">
-            <el-input v-model="new_term.example" type="textarea" :rows="5" />
+            <el-input
+                v-model="new_term.example"
+                type="textarea"
+                :rows="5"
+                placeholder="Напішы сказ ці дыялог з прыкладам ужывання свайго слова. Іншым людзям вельмі дапаможа разуменне кантэксту."
+            />
         </el-form-item>
         <el-form-item label="Тэгі:" prop="tags">
             <div class="add-word__tags-input-wrapper" @click="handleTagsWrapperClick">
+                <!-- свая падказка замест убудаванай: убудаваная не ўмее пераносіцца
+                     на другі радок, а гэты тэкст на тэлефоне ў адзін не змяшчаецца -->
+                <span v-if="!new_term.tags.length && !newTag" class="tags-placeholder">
+                    Напішы тэг. Націсні Enter
+                </span>
                 <el-tag
                     v-for="tag in new_term.tags"
                     :key="tag"
@@ -65,6 +83,7 @@
                     @blur="handleAddTag"
                 />
             </div>
+            <p v-if="tagNotice" class="tags-notice">{{ tagNotice }}</p>
         </el-form-item>
         <input class="submit-btn" type="submit" value="Гатова" :disabled="loading" />
     </el-form>
@@ -147,6 +166,17 @@ const submit = async () => {
             throw error;
         }
     });
+};
+
+const tagNotice = ref('');
+let tagNoticeTimer = null;
+
+const showTagNotice = (text) => {
+    tagNotice.value = text;
+    clearTimeout(tagNoticeTimer);
+    tagNoticeTimer = setTimeout(() => {
+        tagNotice.value = '';
+    }, 3000);
 };
 
 const handleRemoveTag = (tag) => {
@@ -256,8 +286,9 @@ const handleAddTag = () => {
     if (alreadyAdded) {
         // Моўчкі не дадаць — значыць пакінуць чалавека ў здагадках: поле ачысцілася,
         // а тэг не з'явіўся. Называем тое напісанне, якое ўжо стаіць, каб было бачна,
-        // чаму «мова» не дадалася, калі ў картцы «Мова».
-        ElMessage.info(`«${alreadyAdded}» ужо ёсць`);
+        // чаму «мова» не дадалася, калі ў картцы «Мова». Паведамленне стаіць
+        // адразу пад полем — усплыўшы наверсе экрана, яно глядзелася адарваным.
+        showTagNotice(`«${alreadyAdded}» ужо ёсць`);
     } else {
         new_term.tags.push(normalizedValue);
     }

--- a/src/Edit.vue
+++ b/src/Edit.vue
@@ -17,19 +17,37 @@
             <br />
             Зазірні ў
             <router-link :to="{ name: 'rules' }" target="_blank">правілы</router-link>
-            перад тым як даваць новае слова ці яго тлумачэнне.
+            перад тым як даваць новае слова ці яго тлумачэнне. Зазірні ва
+            <!-- новая ўкладка: пераход пасярод запаўнення згубіў бы форму -->
+            <router-link :to="{ name: 'all-tags' }" target="_blank">Усе тэгі</router-link>
+            каб натхніцца.
         </p>
         <el-form-item label="Слова:" prop="term_name">
             <el-input v-model="new_term.term_name" disabled />
         </el-form-item>
         <el-form-item label="Тлумачэнне:" prop="definition">
-            <el-input v-model="new_term.definition" type="textarea" :rows="5" />
+            <el-input
+                v-model="new_term.definition"
+                type="textarea"
+                :rows="5"
+                placeholder="Дай азначэнне свайму слову. Паспрабуй напісаць яго як мага больш нейтральна і зразумела."
+            />
         </el-form-item>
         <el-form-item label="Прыклад:" prop="example">
-            <el-input v-model="new_term.example" type="textarea" :rows="5" />
+            <el-input
+                v-model="new_term.example"
+                type="textarea"
+                :rows="5"
+                placeholder="Напішы сказ ці дыялог з прыкладам ужывання свайго слова. Іншым людзям вельмі дапаможа разуменне кантэксту."
+            />
         </el-form-item>
         <el-form-item label="Тэгі:" prop="tags">
             <div class="add-word__tags-input-wrapper" @click="handleTagsWrapperClick">
+                <!-- свая падказка замест убудаванай: убудаваная не ўмее пераносіцца
+                     на другі радок, а гэты тэкст на тэлефоне ў адзін не змяшчаецца -->
+                <span v-if="!new_term.tags.length && !newTag" class="tags-placeholder">
+                    Напішы тэг. Націсні Enter
+                </span>
                 <el-tag
                     v-for="tag in new_term.tags"
                     :key="tag"
@@ -67,6 +85,7 @@
                     @blur="handleAddTag"
                 />
             </div>
+            <p v-if="tagNotice" class="tags-notice">{{ tagNotice }}</p>
         </el-form-item>
         <input class="submit-btn" type="submit" value="Гатова" :disabled="loading" />
     </el-form>
@@ -189,6 +208,17 @@ const submit = async () => {
     });
 };
 
+const tagNotice = ref('');
+let tagNoticeTimer = null;
+
+const showTagNotice = (text) => {
+    tagNotice.value = text;
+    clearTimeout(tagNoticeTimer);
+    tagNoticeTimer = setTimeout(() => {
+        tagNotice.value = '';
+    }, 3000);
+};
+
 const handleRemoveTag = (tag) => {
     new_term.tags.splice(new_term.tags.indexOf(tag), 1);
 };
@@ -296,8 +326,9 @@ const handleAddTag = () => {
     if (alreadyAdded) {
         // Моўчкі не дадаць — значыць пакінуць чалавека ў здагадках: поле ачысцілася,
         // а тэг не з'явіўся. Называем тое напісанне, якое ўжо стаіць, каб было бачна,
-        // чаму «мова» не дадалася, калі ў картцы «Мова».
-        ElMessage.info(`«${alreadyAdded}» ужо ёсць`);
+        // чаму «мова» не дадалася, калі ў картцы «Мова». Паведамленне стаіць
+        // адразу пад полем — усплыўшы наверсе экрана, яно глядзелася адарваным.
+        showTagNotice(`«${alreadyAdded}» ужо ёсць`);
     } else {
         new_term.tags.push(normalizedValue);
     }


### PR DESCRIPTION
People struggle to fill the add-word card, so every field now carries a grey hint that disappears as soon as they start typing: what to write, how to phrase the definition, why the example matters. The tag field keeps its hint short so it fits on a phone; the advice to press Enter lives below the field instead — a placeholder would vanish exactly when that advice is needed. Field text sizes are unified: the one-line fields were bigger than the textareas. Same hints on the edit page.