### PR TITLE
«Без тэгаў» behaves like any other tag

### DIFF
--- a/public/styles/merged-style.css
+++ b/public/styles/merged-style.css
@@ -1735,8 +1735,3 @@ button:focus-visible {
 .error-caption a {
     text-decoration: underline;
 }
-
-/* «Словы без тэгаў» — не тэг, таму не пілюля: асобны радок пад воблакам */
-.tag-cloud__untagged {
-    margin: 1.5rem 0 0;
-}

--- a/src/AllTags.vue
+++ b/src/AllTags.vue
@@ -17,17 +17,11 @@
                         :class="{ 'tag-cloud__tag--single': tag.count === 1 }"
                         :style="{ fontSize: tag.size + 'rem' }"
                         :title="tag.count + ' ' + wordsLabel(tag.count)"
-                        :to="{ name: 'terms', query: { tag: tag.name } }"
+                        :to="{ name: 'terms', query: tag.query }"
                     >
                         {{ tag.name }}
                     </router-link>
                 </div>
-
-                <p v-if="!loading && !failed && untagged" class="tag-cloud__untagged">
-                    <router-link :to="{ name: 'terms', query: { biez: 'tehau' } }">
-                        Словы без тэгаў ({{ untagged }})
-                    </router-link>
-                </p>
             </div>
         </div>
     </div>
@@ -111,14 +105,28 @@ const cloud = computed(() => {
     const maxCount = Math.max(...entries.map(([, entry]) => entry.count));
     const maxLog = Math.log(maxCount + 1);
 
-    return entries
+    const cloud = entries
         .map(([key, entry]) => ({
             key,
             name: displayName(key, entry.spellings),
             count: entry.count,
+            query: { tag: displayName(key, entry.spellings) },
             size: 0.875 + (Math.log(entry.count + 1) / maxLog) * 1.125,
         }))
         .sort((a, b) => a.key.localeCompare(b.key, 'be'));
+
+    // словы без тэгаў — такая ж пілюля, але ў канцы: гэта не слова з алфавіту
+    if (untagged.value) {
+        cloud.push({
+            key: 'untagged',
+            name: 'Без тэгаў',
+            count: untagged.value,
+            query: { biez: 'tehau' },
+            size: 0.875 + (Math.log(untagged.value + 1) / maxLog) * 1.125,
+        });
+    }
+
+    return cloud;
 });
 
 const wordsLabel = (count) => {

--- a/src/Terms.vue
+++ b/src/Terms.vue
@@ -23,9 +23,9 @@
             </span>
 
             <!-- аўтар — не тэг, таму без зялёнай пілюлі: белы надпіс, як у сартавання -->
-            <span v-if="noTagsQuery" class="sort-autar">
+            <span v-if="noTagsQuery" class="user-tag sort-tag">
                 Без тэгаў
-                <button class="sort-autar__close" type="button" title="Зняць адбор" @click="clearNoTags">
+                <button class="sort-tag__close" type="button" title="Зняць адбор" @click="clearNoTags">
                     <IconCross />
                 </button>
             </span>


### PR DESCRIPTION
Follow-up: instead of a separate line under the cloud, the untagged words are a pill in the cloud itself — same look, sized by word count like the others, and the chip on the list is the same green one a tag filter gets. It stays at the end of the cloud, after the alphabet.